### PR TITLE
Fix PNG export not working in firefox

### DIFF
--- a/r2r.js
+++ b/r2r.js
@@ -279,6 +279,18 @@ function getSvgDataUrl() {
   return data;
 }
 
+function getSvgDataUrlForPngExport() {
+  // this workaround is needed since otherwise PNG export silently fails in Firefox
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=700533
+  svg.setAttribute('width', 1920);
+  svg.setAttribute('height', 1920 * 8 / currentWidth);
+  const xml = new XMLSerializer().serializeToString(svg);
+  svg.setAttribute('width', '100%');
+  svg.removeAttribute('height');
+  const svg64 = btoa(xml);
+  return `data:image/svg+xml;base64, ${svg64}`;
+}
+
 function getPngDataUrl(callback) {
   const canvas = document.createElement("canvas");
   canvas.width = 1920;
@@ -290,7 +302,7 @@ function getPngDataUrl(callback) {
     const png = canvas.toDataURL("image/png");  
     callback(png);
   };
-  img.src = getSvgDataUrl();
+  img.src = getSvgDataUrlForPngExport();
 }
 
 function downloadUrl(url, filename, done) {


### PR DESCRIPTION
Hey,

someone noticed that PNG export generated an empty image in Firefox. I investigated this and it seems this is due to a [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=700533). It looks like Firefox is incapable of rendering an SVG without a fixed width or height attribute to a canvas. I followed some suggestions I found online to create a workaround. Exporting as PNG should work in Firefox now, too. I am no expert, so there might be a better solution to this than mine. Feel free to make changes or give feedback before merging.

Best wishes,
Anne-Victoria